### PR TITLE
Alignment with UP Abstract Base Class PR

### DIFF
--- a/test/test_up_fmap.py
+++ b/test/test_up_fmap.py
@@ -2,6 +2,7 @@ from unified_planning.shortcuts import *  # type: ignore
 from unified_planning.model.multi_agent import *  # type: ignore
 from collections import namedtuple  # type: ignore
 from unified_planning.io.ma_pddl_writer import MAPDDLWriter  # type: ignore
+from unified_planning.plans import PlanKind  # type: ignore
 from unittest import TestCase, main
 import pkg_resources
 from up_fmap import FMAPsolver
@@ -237,7 +238,7 @@ class FMAPtest(TestCase):
             print("%s returned: %s" % (planner.name, result))
             print(
                 "%s returned Sequential Plan: %s"
-                % (planner.name, result.plan.to_sequential_plan())
+                % (planner.name, result.plan.convert_to(PlanKind.SEQUENTIAL_PLAN, problem))
             )
 
         with OneshotPlanner(name="fmap") as planner:

--- a/up_fmap/fmap_planner.py
+++ b/up_fmap/fmap_planner.py
@@ -1,7 +1,8 @@
 import pkg_resources  # type: ignore
 import unified_planning as up  # type: ignore
 from unified_planning.model import ProblemKind  # type: ignore
-from unified_planning.engines import PDDLPlanner, Credits, LogMessage  # type: ignore
+from unified_planning.engines import Engine, Credits, LogMessage  # type: ignore
+from unified_planning.engines.mixins import OneshotPlannerMixin  # type: ignore
 from typing import Callable, Dict, IO, List, Optional, Set, Union, cast  # type: ignore
 from unified_planning.io.ma_pddl_writer import MAPDDLWriter  # type: ignore
 import tempfile
@@ -36,11 +37,12 @@ credits = Credits(
 )
 
 
-class FMAPsolver(PDDLPlanner):
+class FMAPsolver(Engine, OneshotPlannerMixin):
     def __init__(
         self, search_algorithm: Optional[str] = None, heuristic: Optional[str] = None
     ):
-        super().__init__(needs_requirements=False)
+        Engine.__init__(self)
+        OneshotPlannerMixin.__init__(self)
         self.search_algorithm = search_algorithm
         self.heuristic = heuristic
 


### PR DESCRIPTION
In this PR the `FMAP` solver does not inherit from the `PDDLPlanner` anymore.

It is needed to be aligned with the [PR #387](https://github.com/aiplan4eu/unified-planning/pull/387) of the UP, that converts the `PDDLSolver` into an `AbstractBaseClass`, with some `@abstractmethods` that must be implemented.

Since the `FMAP` solver does not implement this methods, it can be a stand-alone solver, without the need to inherit from `PDDLSolver`.