### PR TITLE
Renamed equality problem_kind

### DIFF
--- a/up_fmap/fmap_planner.py
+++ b/up_fmap/fmap_planner.py
@@ -100,7 +100,7 @@ class FMAPsolver(Engine, OneshotPlannerMixin):
         supported_kind.set_typing("HIERARCHICAL_TYPING")
         supported_kind.set_conditions_kind("NEGATIVE_CONDITIONS")
         supported_kind.set_conditions_kind("DISJUNCTIVE_CONDITIONS")
-        supported_kind.set_conditions_kind("EQUALITY")
+        supported_kind.set_conditions_kind("EQUALITIES")
         supported_kind.set_conditions_kind("EXISTENTIAL_CONDITIONS")
         supported_kind.set_conditions_kind("UNIVERSAL_CONDITIONS")
         supported_kind.set_effects_kind("CONDITIONAL_EFFECTS")


### PR DESCRIPTION
This PR aligns the up-fmap repo with the https://github.com/aiplan4eu/unified-planning/pull/365.

As specified in the sent email, we also added some new effects_kind, in particular:
-     `STATIC_FLUENTS_IN_NUMERIC_ASSIGNMENTS`
-     `STATIC_FLUENTS_IN_BOOLEAN_ASSIGNMENTS`
-     `FLUENTS_IN_NUMERIC_ASSIGNMENTS`
-     `FLUENTS_IN_BOOLEAN_ASSIGNMENTS`

Add them to the supported_kind if they are supported in the FMAP integration.

Let me know if there is any issue.